### PR TITLE
add publish_dir for multiqc to modules.config

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -123,4 +123,11 @@ process {
         ]
     }
 
+    withName: MULTIQC {
+        publishDir = [
+            path: { "${params.outdir}/multiqc" },
+            mode: 'copy',
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
 }


### PR DESCRIPTION
Multiqc output was saved to db_tables (default). This was changed by adding a separate directory for multiqc results to be stored in.