### PR TITLE
Chunk-wise processing of peptides and optimized pandas operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 
 - [#11](https://github.com/nf-core/metapep/pull/11) - Template update for nf-core/tools version 2.3
 - [#13](https://github.com/nf-core/metapep/pull/13) - Update modules custom/dumpsoftwareversions and prodigal
+- [#21](https://github.com/nf-core/metapep/pull/21) - Optimized peptide processing and Pandas joining in process `SPLIT_PRED_TASK` to reduce memory usage.
 
 ### `Dependencies`
 

--- a/bin/gen_prediction_chunks.py
+++ b/bin/gen_prediction_chunks.py
@@ -91,29 +91,32 @@ try:
 
     # Read input files
     # NOTE try out if datatable package can be used and would be faster or more memory efficient
-    protein_peptide_occs               = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t').set_index('peptide_id').sort_index()  # NOTE could this be handled more efficiently somehow (easily)?
-    protein_peptide_occs.index         = pd.to_numeric(protein_peptide_occs.index, downcast="unsigned")
-    protein_peptide_occs["protein_id"] = pd.to_numeric(protein_peptide_occs["protein_id"], downcast="unsigned")
+    # downcast df columns that will not be used as indices to save mem usage
+    # (skip index columns to avoid upcasting with set_index() and increased runtime)
+    protein_peptide_occs = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t').set_index('peptide_id').sort_index()  # NOTE could this be handled more efficiently somehow (easily)?
 
-    entities_proteins_occs                              = pd.read_csv(args.entities_proteins_occ, sep='\t')
-    entities_proteins_occs[["entity_id", "protein_id"]] = entities_proteins_occs[["entity_id", "protein_id"]].apply(pd.to_numeric, downcast="unsigned")
+    entities_proteins_occs              = pd.read_csv(args.entities_proteins_occ, sep='\t')
+    entities_proteins_occs["entity_id"] = pd.to_numeric(entities_proteins_occs["entity_id"], downcast="unsigned")
 
-    microbiomes_entities_occs                                 = pd.read_csv(args.microbiomes_entities_occ, usecols=['microbiome_id', 'entity_id'], sep='\t')
-    microbiomes_entities_occs[["microbiome_id", "entity_id"]] = microbiomes_entities_occs[["microbiome_id", "entity_id"]].apply(pd.to_numeric, downcast="unsigned")
+    microbiomes_entities_occs                  = pd.read_csv(args.microbiomes_entities_occ, usecols=['microbiome_id', 'entity_id'], sep='\t')
+    microbiomes_entities_occs["microbiome_id"] = pd.to_numeric(microbiomes_entities_occs["microbiome_id"], downcast="unsigned")
+    microbiomes_entities_occs["entity_id"]     = pd.to_numeric(microbiomes_entities_occs["entity_id"], downcast="unsigned")
 
-    conditions                                    = pd.read_csv(args.conditions, usecols=['condition_id', 'microbiome_id'], sep='\t')
-    conditions[["condition_id", "microbiome_id"]] = conditions[["condition_id", "microbiome_id"]].apply(pd.to_numeric, downcast="unsigned")
+    conditions                  = pd.read_csv(args.conditions, usecols=['condition_id', 'microbiome_id'], sep='\t')
+    conditions["condition_id"]  = pd.to_numeric(conditions["condition_id"], downcast="unsigned")
+    conditions["microbiome_id"] = pd.to_numeric(conditions["microbiome_id"], downcast="unsigned")
 
-    condition_allele_map                                = pd.read_csv(args.condition_allele_map, sep='\t')
-    condition_allele_map[["condition_id", "allele_id"]] = condition_allele_map[["condition_id", "allele_id"]].apply(pd.to_numeric, downcast="unsigned")
+    condition_allele_map                 = pd.read_csv(args.condition_allele_map, sep='\t')
+    condition_allele_map["condition_id"] = pd.to_numeric(condition_allele_map["condition_id"], downcast="unsigned")
+    condition_allele_map["allele_id"]    = pd.to_numeric(condition_allele_map["allele_id"], downcast="unsigned")
 
     alleles              = pd.read_csv(args.alleles, sep='\t')
     alleles["allele_id"] = pd.to_numeric(alleles["allele_id"], downcast="unsigned")
-    # allele_name does not need to be converted to categorical type, since it is anyway not used for larger dfs
+    # not converting allele_name to categorical type, since it is anyway not used for larger dfs
 
     # Print info including memory usage for input DataFrames
     # (Pandas df ~ 3x the size of input data)
-    print_mem = 'deep'    # 'deep' (extra computational costs) or None
+    print_mem = None    # 'deep' (extra computational costs) or None
     print("\nInfo: protein_peptide_occs", flush=True)
     protein_peptide_occs.info(verbose = False, memory_usage=print_mem)
     print("\nInfo: entities_proteins_occs", flush=True)

--- a/bin/gen_prediction_chunks.py
+++ b/bin/gen_prediction_chunks.py
@@ -91,13 +91,25 @@ try:
 
     # Read input files
     # NOTE try out if datatable package can be used and would be faster or more memory efficient
-    # peptides                  = pd.read_csv(args.peptides, sep='\t', index_col="peptide_id").sort_index() -> read in chunk-wise
-    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t').set_index('peptide_id').sort_index()  # NOTE could this be handled more efficiently somehow (easily)?
-    entities_proteins_occs    = pd.read_csv(args.entities_proteins_occ, sep='\t')
-    microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, usecols=['microbiome_id', 'entity_id'], sep='\t')
-    conditions                = pd.read_csv(args.conditions, usecols=['condition_id', 'microbiome_id'], sep='\t')
-    condition_allele_map      = pd.read_csv(args.condition_allele_map, sep='\t')
-    alleles                   = pd.read_csv(args.alleles, sep='\t')
+    protein_peptide_occs               = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t').set_index('peptide_id').sort_index()  # NOTE could this be handled more efficiently somehow (easily)?
+    protein_peptide_occs.index         = pd.to_numeric(protein_peptide_occs.index, downcast="unsigned")
+    protein_peptide_occs["protein_id"] = pd.to_numeric(protein_peptide_occs["protein_id"], downcast="unsigned")
+
+    entities_proteins_occs                              = pd.read_csv(args.entities_proteins_occ, sep='\t')
+    entities_proteins_occs[["entity_id", "protein_id"]] = entities_proteins_occs[["entity_id", "protein_id"]].apply(pd.to_numeric, downcast="unsigned")
+
+    microbiomes_entities_occs                                 = pd.read_csv(args.microbiomes_entities_occ, usecols=['microbiome_id', 'entity_id'], sep='\t')
+    microbiomes_entities_occs[["microbiome_id", "entity_id"]] = microbiomes_entities_occs[["microbiome_id", "entity_id"]].apply(pd.to_numeric, downcast="unsigned")
+
+    conditions                                    = pd.read_csv(args.conditions, usecols=['condition_id', 'microbiome_id'], sep='\t')
+    conditions[["condition_id", "microbiome_id"]] = conditions[["condition_id", "microbiome_id"]].apply(pd.to_numeric, downcast="unsigned")
+
+    condition_allele_map                                = pd.read_csv(args.condition_allele_map, sep='\t')
+    condition_allele_map[["condition_id", "allele_id"]] = condition_allele_map[["condition_id", "allele_id"]].apply(pd.to_numeric, downcast="unsigned")
+
+    alleles              = pd.read_csv(args.alleles, sep='\t')
+    alleles["allele_id"] = pd.to_numeric(alleles["allele_id"], downcast="unsigned")
+    # allele_name does not need to be converted to categorical type, since it is anyway not used for larger dfs
 
     # Print info including memory usage for input DataFrames
     # (Pandas df ~ 3x the size of input data)

--- a/bin/gen_prediction_chunks.py
+++ b/bin/gen_prediction_chunks.py
@@ -92,10 +92,10 @@ try:
     # Read input files
     # NOTE try out if datatable package can be used and would be faster or more memory efficient
     # peptides                  = pd.read_csv(args.peptides, sep='\t', index_col="peptide_id").sort_index() -> read in chunk-wise
-    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, sep='\t').drop(columns="count").set_index('peptide_id').sort_index()  # NOTE could this be handled more efficiently somehow (easily)?
+    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t').set_index('peptide_id').sort_index()  # NOTE could this be handled more efficiently somehow (easily)?
     entities_proteins_occs    = pd.read_csv(args.entities_proteins_occ, sep='\t')
-    microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, sep='\t').drop(columns="entity_weight")
-    conditions                = pd.read_csv(args.conditions, sep='\t').drop(columns="condition_name")
+    microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, usecols=['microbiome_id', 'entity_id'], sep='\t')
+    conditions                = pd.read_csv(args.conditions, usecols=['condition_id', 'microbiome_id'], sep='\t')
     condition_allele_map      = pd.read_csv(args.condition_allele_map, sep='\t')
     alleles                   = pd.read_csv(args.alleles, sep='\t')
 

--- a/modules/local/split_pred_tasks.nf
+++ b/modules/local/split_pred_tasks.nf
@@ -3,10 +3,11 @@ process SPLIT_PRED_TASKS {
     label 'process_high_memory'
     label 'cache_lenient'
 
-    conda (params.enable_conda ? "conda-forge::pandas=1.1.5" : null)
+    // TODO update container
+    conda (params.enable_conda ? "conda-forge::pandas=1.4.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pandas:1.1.5' :
-        'quay.io/biocontainers/pandas:1.1.5' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-629aec3ba267b06a1efc3ec454c0f09e134f6ee2:3b083bb5eae6e491b8579589b070fa29afbea2a1-0' :
+        'quay.io/biocontainers/mulled-v2-629aec3ba267b06a1efc3ec454c0f09e134f6ee2:3b083bb5eae6e491b8579589b070fa29afbea2a1-0' }"
 
     input:
     path(peptides            )
@@ -34,6 +35,7 @@ process SPLIT_PRED_TASKS {
                             --conditions "$conditions" \\
                             --condition-allele-map "$conditions_alleles" \\
                             --max-chunk-size $pred_chunk_size \\
+                            --proc-chunk-size 7500000 \\
                             $subsampling \\
                             --alleles "$alleles" \\
                             --outdir .

--- a/modules/local/split_pred_tasks.nf
+++ b/modules/local/split_pred_tasks.nf
@@ -25,6 +25,7 @@ process SPLIT_PRED_TASKS {
 
     script:
     def pred_chunk_size       = params.pred_chunk_size
+    def proc_chunk_size       = params.proc_chunk_size
     def subsampling = params.sample_n > 0 ? "--sample_n ${params.sample_n}" : ""
     """
     gen_prediction_chunks.py --peptides "$peptides" \\
@@ -34,7 +35,7 @@ process SPLIT_PRED_TASKS {
                             --conditions "$conditions" \\
                             --condition-allele-map "$conditions_alleles" \\
                             --max-chunk-size $pred_chunk_size \\
-                            --proc-chunk-size 7500000 \\
+                            --proc-chunk-size $proc_chunk_size \\
                             $subsampling \\
                             --alleles "$alleles" \\
                             --outdir .

--- a/modules/local/split_pred_tasks.nf
+++ b/modules/local/split_pred_tasks.nf
@@ -3,11 +3,10 @@ process SPLIT_PRED_TASKS {
     label 'process_high_memory'
     label 'cache_lenient'
 
-    // TODO update container
-    conda (params.enable_conda ? "conda-forge::pandas=1.4.2" : null)
+    conda (params.enable_conda ? "conda-forge::pandas=1.4.3" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-629aec3ba267b06a1efc3ec454c0f09e134f6ee2:3b083bb5eae6e491b8579589b070fa29afbea2a1-0' :
-        'quay.io/biocontainers/mulled-v2-629aec3ba267b06a1efc3ec454c0f09e134f6ee2:3b083bb5eae6e491b8579589b070fa29afbea2a1-0' }"
+        'https://depot.galaxyproject.org/singularity/pandas:1.4.3' :
+        'quay.io/biocontainers/pandas:1.4.3' }"
 
     input:
     path(peptides            )

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,7 @@ params {
     // predict epitopes
     pred_method = 'syfpeithi'
     pred_chunk_size = 75000
+    proc_chunk_size = 7500000
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -254,7 +254,7 @@
                 "proc_chunk_size": {
                     "type": "integer",
                     "default": 7500000,
-                    "description": "Chunk size (#peptides) used to process peptides within process SPLIT_PRED_TASKS to keep memory usage low, i.e. when peptides are joined with Pandas against other datatables to obtain allele_id for epitope prediction task."
+                    "description": "Limits the number of peptides processed at once in the SPLIT_PRED_TASKS process and thus the memory footprint of the process. This parameter does not affect the pred_chunk_size parameter."
                 },
                 "prodigal_mode": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -251,6 +251,11 @@
                     "default": 75000,
                     "description": "Maximum chunk size (#peptides) for epitope prediction jobs"
                 },
+                "proc_chunk_size": {
+                    "type": "integer",
+                    "default": 7500000,
+                    "description": "Chunk size (#peptides) used to process peptides within process SPLIT_PRED_TASKS to keep memory usage low, i.e. when peptides are joined with Pandas against other datatables to obtain allele_id for epitope prediction task."
+                },
                 "prodigal_mode": {
                     "type": "string",
                     "default": "meta",


### PR DESCRIPTION
Since currently some processes that merge db tables containing peptides, such as `SPLIT_PRED_TASKS`,  cause problems because they require large amounts of memory for larger input datasets, I rewrote the code in `gen_prediction_chunks.py`. 
Main changes:

- `peptides` input is read in and processed chunk-wise (without changing the final output chunks). Added parameter `proc_chunk_size`.
- using more efficient pandas operations, e.g. using `join()` on sorted indices instead of applying `merge()`
- dropped not required column `allele_name` in df
- not reading in anymore not used columns of CSV files, i.e. using `usecols` Pandas parameter of `read_csv()` function
- downcasting df columns as much as possible to save further memory (only columns that are not used as indices, since others would be upcasted again with set_index() and that would increase runtime)

With the given parameters, on a full-size test this reduced the memory usage from ~214GB to 36GB, while the runtime was slightly reduced (~1h07min to ~57min). The impact will of course depend on the used chunk-size parameters.

Now, one of the biggest impacts on the memory usage is caused by loading the (full) `protein_peptides` datatable, which requires for the Pandas df ~3x the size of the original input size. For now this should be fine, one can still think about further optimisations in the future if necessary.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
