### PR TITLE
Optimize prep entity binding ratios2

### DIFF
--- a/bin/prepare_entity_binding_ratios.py
+++ b/bin/prepare_entity_binding_ratios.py
@@ -67,9 +67,10 @@ def main(args=None):
     args = parse_args(args)
 
     # Read input files
+    # (loading predictions allele-wise with skiprows doesn't seem to work, could still be considered to be filtered afterwards if this becomes bottleneck)
     predictions               = pd.read_csv(args.predictions, sep='\t')
-    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t')
     # (binding ratio: peptide occurrences within multiple proteins of an entity are counted, while occurrences within the same protein are not considered currently)
+    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t')
     entities_proteins_occs    = pd.read_csv(args.entities_proteins_occ, sep='\t')
     microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, sep='\t')
     conditions                = pd.read_csv(args.conditions, sep='\t')

--- a/bin/prepare_entity_binding_ratios.py
+++ b/bin/prepare_entity_binding_ratios.py
@@ -72,12 +72,14 @@ def main(args=None):
     predictions["prediction_score"] = pd.to_numeric(predictions["prediction_score"], downcast="float")
 
     # (binding ratio: peptide occurrences within multiple proteins of an entity are counted, while occurrences within the same protein are not considered currently)
-    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], index_col="protein_id", sep='\t').sort_index()
-    entities_proteins_occs    = pd.read_csv(args.entities_proteins_occ, sep='\t')
-    microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, sep='\t')
-    conditions                = pd.read_csv(args.conditions, sep='\t')
-    condition_allele_map      = pd.read_csv(args.condition_allele_map, sep='\t')
-    alleles                   = pd.read_csv(args.alleles, sep='\t')
+    protein_peptide_occs         = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], index_col="protein_id", sep='\t').sort_index()
+    entities_proteins_occs       = pd.read_csv(args.entities_proteins_occ, sep='\t')
+    microbiomes_entities_occs    = pd.read_csv(args.microbiomes_entities_occ, sep='\t')
+    conditions                   = pd.read_csv(args.conditions, sep='\t')
+    # convert condition_name column to categorical datatype to reduce memory usage (condition_id column is anyway not used for bigger dfs)
+    conditions["condition_name"] = conditions["condition_name"].astype("category")
+    condition_allele_map         = pd.read_csv(args.condition_allele_map, sep='\t')
+    alleles                      = pd.read_csv(args.alleles, sep='\t')
 
     print_mem = 'deep'      # 'deep' (extra computational costs) or None
     print("\nInfo: predictions", flush=True)

--- a/bin/prepare_entity_binding_ratios.py
+++ b/bin/prepare_entity_binding_ratios.py
@@ -113,8 +113,8 @@ def main(args=None):
                         .merge(condition_allele_map[condition_allele_map.allele_id == allele_id]) \
                         .drop(columns="condition_id") \
                         .merge(predictions) \
-                        .drop(columns="allele_id")
-                # -> entity_weight, peptide_id, condition_name, prediction_score (multiple rows for occurrences in multiple proteins within entity_id)
+                        .drop(columns=["allele_id", "peptide_id"])
+                # -> entity_weight, condition_name, prediction_score (multiple rows for occurrences in multiple proteins within entity_id)
                 # merged against condition_allele_map to discard prediction_scores for the current allele that are not requested for the respective condition_id
 
                 data["binder"] = data["prediction_score"].apply(call_binder, method=args.method)

--- a/bin/prepare_entity_binding_ratios.py
+++ b/bin/prepare_entity_binding_ratios.py
@@ -75,6 +75,12 @@ def main(args=None):
     condition_allele_map      = pd.read_csv(args.condition_allele_map, sep='\t')
     alleles                   = pd.read_csv(args.alleles, sep='\t')
 
+    print_mem = 'deep'      # 'deep' (extra computational costs) or None
+    print("\nInfo: predictions", flush=True)
+    predictions.info(verbose = False, memory_usage=print_mem)
+    print("\nInfo: protein_peptide_occs", flush=True)
+    protein_peptide_occs.info(verbose = False, memory_usage=print_mem)
+
     # Create output directory if it doesn't exist
     if os.path.exists(args.outdir) and not os.path.isdir(args.outdir):
         print("ERROR - The target path is not a directory", file = sys.stderr)
@@ -101,11 +107,17 @@ def main(args=None):
 
         data["binder"] = data["prediction_score"].apply(call_binder, method=args.method)
 
+        print("\nInfo: data 1", flush=True)
+        data.info(verbose = False, memory_usage=print_mem)
+
         data = data \
                 .drop(columns="prediction_score") \
                 .groupby(["entity_id", "condition_name", "entity_weight"], group_keys=False).apply(lambda x : get_binding_ratio(x)) \
                 .reset_index(drop=True) \
                 .drop(columns=["entity_id"])
+
+        print("\nInfo: data 2", flush=True)
+        data.info(verbose = False, memory_usage=print_mem)
         # NOTE
         # binding ratio: occurences within multiple proteins of an entity are counted, while occurences within the same protein are not counted
 

--- a/bin/prepare_entity_binding_ratios.py
+++ b/bin/prepare_entity_binding_ratios.py
@@ -68,7 +68,8 @@ def main(args=None):
 
     # Read input files
     predictions               = pd.read_csv(args.predictions, sep='\t')
-    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, sep='\t').drop(columns="count")
+    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, usecols=['protein_id', 'peptide_id'], sep='\t')
+    # (binding ratio: peptide occurrences within multiple proteins of an entity are counted, while occurrences within the same protein are not considered currently)
     entities_proteins_occs    = pd.read_csv(args.entities_proteins_occ, sep='\t')
     microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, sep='\t')
     conditions                = pd.read_csv(args.conditions, sep='\t')
@@ -128,9 +129,6 @@ def main(args=None):
 
                 print("\nInfo: data 2", flush=True)
                 data.info(verbose = False, memory_usage=print_mem)
-
-                # NOTE
-                # binding ratio: occurences within multiple proteins of an entity are counted, while occurences within the same protein are not counted
 
                 if not data.empty:
                     data[["condition_name", "binding_rate", "entity_weight"]].to_csv(outfile, sep="\t", index=False, mode='a', header=write_header)


### PR DESCRIPTION
And I optimized the `prepare_entity_binding_ratios.py` script to reduce the memory usage. The main changes are:

- needs to be changed (impact on runtime)

Additionally:

 - fixed a bug in the computation of entity-wise binding ratios
 
If we add more such scripts for downstream analysis, one needs to think how to efficiently do this. In anyway one needs to keep the data model in mind to avoid creating too huge dataframes. One can also think about a script to extract the required tables for multiple plots in one step, similar to what AntoniaSchuster did.
In general, for this it might make sense to consider what type of other downstream analyses might be of interest here. 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
