### PR TITLE
Optimize `prepare_score_distribution.py`

### DIFF
--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -88,12 +88,36 @@ def main(args=None):
 
     # Read input files
     predictions = pd.read_csv(args.predictions, sep="\t", index_col="peptide_id").sort_index()
+    predictions["allele_id"] = pd.to_numeric(predictions["allele_id"], downcast="unsigned")
+    predictions["prediction_score"] = pd.to_numeric(predictions["prediction_score"], downcast="float")
+
     protein_peptide_occs = pd.read_csv(args.protein_peptide_occ, sep="\t", index_col="peptide_id").sort_index()
+    protein_peptide_occs["protein_id"] = pd.to_numeric(protein_peptide_occs["protein_id"], downcast="unsigned")
+    protein_peptide_occs["count"] = pd.to_numeric(protein_peptide_occs["count"], downcast="unsigned")
+
     entities_proteins_occs = pd.read_csv(args.entities_proteins_occ, sep="\t")
+    entities_proteins_occs["entity_id"] = pd.to_numeric(entities_proteins_occs["entity_id"], downcast="unsigned")
+    entities_proteins_occs["protein_id"] = pd.to_numeric(entities_proteins_occs["protein_id"], downcast="unsigned")
+
     microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, sep="\t")
+    microbiomes_entities_occs["microbiome_id"] = pd.to_numeric(
+        microbiomes_entities_occs["microbiome_id"], downcast="unsigned"
+    )
+    microbiomes_entities_occs["entity_id"] = pd.to_numeric(microbiomes_entities_occs["entity_id"], downcast="unsigned")
+    microbiomes_entities_occs["entity_weight"] = pd.to_numeric(
+        microbiomes_entities_occs["entity_weight"], downcast="float"
+    )
+
     conditions = pd.read_csv(args.conditions, sep="\t")
+    conditions["condition_id"] = pd.to_numeric(conditions["condition_id"], downcast="unsigned")
+    conditions["microbiome_id"] = pd.to_numeric(conditions["microbiome_id"], downcast="unsigned")
+
     condition_allele_map = pd.read_csv(args.condition_allele_map, sep="\t")
+    condition_allele_map["condition_id"] = pd.to_numeric(condition_allele_map["condition_id"], downcast="unsigned")
+    condition_allele_map["allele_id"] = pd.to_numeric(condition_allele_map["allele_id"], downcast="unsigned")
+
     alleles = pd.read_csv(args.alleles, sep="\t")
+    alleles["allele_id"] = pd.to_numeric(alleles["allele_id"], downcast="unsigned")
 
     print("\nInfo: predictions", flush=True)
     predictions.info(verbose=False, memory_usage=print_mem)

--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -177,6 +177,7 @@ def main(args=None):
                 .drop(columns="protein_id")
             )
             # (merge() might change index, so reset_index(..) before)
+            # -> index, peptide_id, prediction_score, allele_id, count, entity_weight, condition_name
             # TODO include counts!
 
             print("\nInfo: data after merging protein_info", flush=True)
@@ -189,6 +190,7 @@ def main(args=None):
                 .reset_index(name="weight_sum")
                 .drop(columns="peptide_id")
             )
+            # -> index, prediction_score, condition_name, allele_id, weight_sum
 
             # NOTE
             # for each peptide in a condition the weight is computed as follows:

--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -88,7 +88,7 @@ def main(args=None):
 
     # Read input files
     predictions = pd.read_csv(args.predictions, sep="\t", index_col="peptide_id").sort_index()
-    protein_peptide_occs = pd.read_csv(args.protein_peptide_occ, sep="\t", index_col="peptide_id").drop(columns="count").sort_index()
+    protein_peptide_occs = pd.read_csv(args.protein_peptide_occ, sep="\t", index_col="peptide_id").sort_index()
     entities_proteins_occs = pd.read_csv(args.entities_proteins_occ, sep="\t")
     microbiomes_entities_occs = pd.read_csv(args.microbiomes_entities_occ, sep="\t")
     conditions = pd.read_csv(args.conditions, sep="\t")

--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -23,6 +23,7 @@ import os
 import csv
 
 import pandas as pd
+import datetime
 
 ####################################################################################################
 
@@ -71,6 +72,10 @@ def main(args=None):
     args = parse_args(args)
     print_mem = "deep"  # 'deep' (extra computational costs) or None
 
+    now = datetime.datetime.now()
+    print("Start date and time : ")
+    print(now.strftime("%Y-%m-%d %H:%M:%S"))
+
     # Read input files
     predictions = pd.read_csv(args.predictions, sep="\t")
     protein_peptide_occs = pd.read_csv(args.protein_peptide_occ, sep="\t").drop(columns="count")
@@ -97,6 +102,10 @@ def main(args=None):
     # for each allele separately (to save mem)
     for allele_id in alleles.allele_id:
         print("Process allele: ", allele_id, flush=True)
+
+        now = datetime.datetime.now()
+        print("Time: ...")
+        print(now.strftime("%Y-%m-%d %H:%M:%S"))
 
         data = (
             predictions[predictions.allele_id == allele_id]

--- a/modules/local/prepare_score_distribution.nf
+++ b/modules/local/prepare_score_distribution.nf
@@ -2,10 +2,10 @@ process PREPARE_SCORE_DISTRIBUTION {
     label "process_long"
     label "process_high_memory"
 
-    conda "conda-forge::pandas=1.1.5"
+    conda "conda-forge::pandas=1.5"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pandas:1.1.5' :
-        'quay.io/biocontainers/pandas:1.1.5' }"
+        'https://depot.galaxyproject.org/singularity/pandas:1.5' :
+        'quay.io/biocontainers/pandas:1.5' }"
 
     input:
     path predictions

--- a/modules/local/prepare_score_distribution.nf
+++ b/modules/local/prepare_score_distribution.nf
@@ -21,6 +21,7 @@ process PREPARE_SCORE_DISTRIBUTION {
     path "versions.yml"                  , emit: versions
 
     script:
+    def chunk_size = params.ds_prep_chunk_size
     """
     prepare_score_distribution.py --predictions "$predictions" \\
                             --protein-peptide-occ "$proteins_peptides" \\
@@ -29,6 +30,7 @@ process PREPARE_SCORE_DISTRIBUTION {
                             --conditions "$conditions" \\
                             --condition-allele-map "$conditions_alleles" \\
                             --alleles "$alleles" \\
+                            --chunk-size $chunk_size \\
                             --outdir .
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
- Changed to chunk-wise processing based on `peptide_id`s
- Use `join()` on sorted index instead of `merge()`
- Include peptide counts for computation of output weights: for each condition each `prediction_score` has an assigned `weight_sum`, which is the sum of `count` * `entity_weight` over all proteins in which the corresponding peptide occurs
- Added down casting of numerical columns where possible (i.e. that are not used as index)

Resources:

...

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
