### PR TITLE
Binned score distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 
 - [#26](https://github.com/nf-core/metapep/pull/26) - Optimized memory usage of `PREPARE_ENTITY_BINDING_RATIOS`: peptide_ids are processed chunk-wise now. Added `ds_prep_chunk_size` parameter.
 - [#32](https://github.com/nf-core/metapep/pull/32) - Optimized memory usage of `PREPARE_SCORE_DISTRIBUTION`: peptide_ids are processed chunk-wise now. Peptide `count`s are used for `weight_sum` computation.
+- [#33](https://github.com/nf-core/metapep/pull/33) - Output already binned scores in `PREPARE_SCORE_DISTRIBUTION` to reduce resources needed for `PLOT_SCORE_DISTRIBUTION`.
 
 ### `Fixed`
 

--- a/bin/plot_score_distribution.R
+++ b/bin/plot_score_distribution.R
@@ -37,6 +37,9 @@ allele_name <- alleles[match, ]$allele_name
 allele_str <- str_replace_all(allele_name, '\\*', '_')
 allele_str <- str_replace_all(allele_str, '\\:', '_')
 
+# Keep only rows with weight > 0
+data <- data[data$weight_sum>0, ]
+
 if (method == "syfpeithi"){
     score_threshold <- 0.50
 } else {
@@ -49,11 +52,13 @@ p <- ggplot(data, aes(x=condition_name, y=prediction_score, weight = weight_sum,
     ylab("Epitope prediction score") +
     xlab("Condition") +
     ggtitle(allele_name) +
-    geom_violin(draw_quantiles = c(0.25, 0.5, 0.75)) +
+    geom_violin(draw_quantiles = c(0.25, 0.5, 0.75), adjust = 0.2) +
     scale_fill_brewer(palette="Dark2") +
     geom_hline(yintercept=score_threshold) +
     theme_classic() +
     theme(legend.position="none", plot.title = element_text(hjust = 0.5))
+# TODO which bandwidth to use best for smoothing?
+# (somehow also affects printed quantiles)
 
 ggsave(paste0("prediction_score_distribution.", allele_str, ".pdf"), height=5, width=5)
 

--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -23,6 +23,7 @@ import os
 import csv
 
 import pandas as pd
+import numpy as np
 import datetime
 
 ####################################################################################################
@@ -131,6 +132,11 @@ def main(args=None):
     elif not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
 
+    # Create prediction_score bin intervals to reduce number of data points for plotting
+    bin_results, bin_edges = pd.cut(
+        predictions["prediction_score"], bins=1000, retbins = True
+    )
+
     print("Prepare df with protein info ...", flush=True)
     # Prepare df for joining protein information
     # (get condition_name, entity_weights and filter for condition entities)
@@ -152,7 +158,7 @@ def main(args=None):
     for allele_id in alleles.allele_id:
         outfile = open(os.path.join(args.outdir, "prediction_scores.allele_" + str(allele_id) + ".tsv"), "w")
         outfile_dict[allele_id] = outfile
-    print_header = True
+    print_header = ["prediction_score", "condition_name", "weight_sum"]
 
     try:
         # Process predictions chunk-wise based on peptide_ids
@@ -204,9 +210,23 @@ def main(args=None):
             print("\nInfo: final data", flush=True)
             data.info(verbose=False, memory_usage=print_mem)
 
+            # Assign prediction_scores to precomputed bins, group and sum up weights
+            data["prediction_score_bin"] = pd.cut(
+                data["prediction_score"], bins=bin_edges
+            )
+            data = (
+                data.groupby(["prediction_score_bin", "condition_name", "allele_id"]).agg(
+                    agg_weight=("weight_sum", "sum"),
+                )
+                .reset_index()
+            )
+            # For the sake of simplicity, just use bin center for plotting (anyway smoothed for violin plots)
+            # (todo: think about more elegant way for visualization if necessary)
+            data["prediction_score_bin_center"] = data["prediction_score_bin"].apply(lambda x: np.mean([x.left, x.right]))
+
             # Write out results for each allele
             for allele_id in outfile_dict.keys():
-                data[data.allele_id == allele_id][["prediction_score", "condition_name", "weight_sum"]].to_csv(
+                data[data.allele_id == allele_id][["prediction_score_bin_center", "condition_name", "agg_weight"]].to_csv(
                     outfile_dict[allele_id], mode="a", sep="\t", index=False, header=print_header
                 )
             print_header = False

--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -133,9 +133,7 @@ def main(args=None):
         os.makedirs(args.outdir)
 
     # Create prediction_score bin intervals to reduce number of data points for plotting
-    bin_results, bin_edges = pd.cut(
-        predictions["prediction_score"], bins=1000, retbins = True
-    )
+    bin_results, bin_edges = pd.cut(predictions["prediction_score"], bins=1000, retbins=True)
 
     print("Prepare df with protein info ...", flush=True)
     # Prepare df for joining protein information
@@ -211,24 +209,25 @@ def main(args=None):
             data.info(verbose=False, memory_usage=print_mem)
 
             # Assign prediction_scores to precomputed bins, group and sum up weights
-            data["prediction_score_bin"] = pd.cut(
-                data["prediction_score"], bins=bin_edges
-            )
+            data["prediction_score_bin"] = pd.cut(data["prediction_score"], bins=bin_edges)
             data = (
-                data.groupby(["prediction_score_bin", "condition_name", "allele_id"]).agg(
+                data.groupby(["prediction_score_bin", "condition_name", "allele_id"])
+                .agg(
                     agg_weight=("weight_sum", "sum"),
                 )
                 .reset_index()
             )
             # For the sake of simplicity, just use bin center for plotting (anyway smoothed for violin plots)
             # (todo: think about more elegant way for visualization if necessary)
-            data["prediction_score_bin_center"] = data["prediction_score_bin"].apply(lambda x: np.mean([x.left, x.right]))
+            data["prediction_score_bin_center"] = data["prediction_score_bin"].apply(
+                lambda x: np.mean([x.left, x.right])
+            )
 
             # Write out results for each allele
             for allele_id in outfile_dict.keys():
-                data[data.allele_id == allele_id][["prediction_score_bin_center", "condition_name", "agg_weight"]].to_csv(
-                    outfile_dict[allele_id], mode="a", sep="\t", index=False, header=print_header
-                )
+                data[data.allele_id == allele_id][
+                    ["prediction_score_bin_center", "condition_name", "agg_weight"]
+                ].to_csv(outfile_dict[allele_id], mode="a", sep="\t", index=False, header=print_header)
             print_header = False
 
         print("Done!", flush=True)


### PR DESCRIPTION
For larger input data, the resulting tables containing the peptides prediction scores for plotting become quite large. 
To reduce the number of data points that have to be processed in `PLOT_SCORE_DISTRIBUTION` I changed the process `PREPARE_SCORE_DISTRIBUTION` to generate already binned scores. To be precise just using the bin centers (of 1000bins currently), i.e. the resolution is still high enough and the resulting violin plots look the same (if still needed, one could think about more elegant solutions in the future).

For a full-size test dataset this reduced the resources used for `PREPARE_SCORE_DISTRIBUTION` 

- 64 GB - 64 GB
- **1 h 15 min** -> **43 min** (reduced I/O)

as well as for `PLOT_SCORE_DISTRIBUTION`

- **76 GB** -> **288 MB**
- 9 min -> 4 s

(To address the issue by subsampling is difficult here, since the peptides occur with different counts in different proteins, and in different proteins of different entities etc.. Thus one would need to take care to not introduce biases here.)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
