### PR TITLE
Fix CI tests using NCBI secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           version: "${{ matrix.NXF_VER }}"
 
-      - name: Run pipeline with test data
+      - name: Run pipeline with assembly test data
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
+          nextflow run ${GITHUB_WORKSPACE} -profile test_assembly_only,docker --outdir ./results
 
   profile:
     name: Run additional profile tests
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests: ["test_assembly_only", "test_bins"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
+        tests: ["test_bins", "test_coassembly"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests: ["test_mouse", "test_tiny"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
+        tests: ["test", "test_mouse", "test_tiny"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
   all_profiles:
     name: Run all additional profile tests that require ncbi credentials
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/metapep') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/conf/test_coassembly.config
+++ b/conf/test_coassembly.config
@@ -4,7 +4,7 @@
  * -------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:
- *   nextflow run nf-core/metapep -profile test_bins,<docker/singularity>
+ *   nextflow run nf-core/metapep -profile test_coassembly,<docker/singularity>
  */
 
 params {


### PR DESCRIPTION
TEST how to use secrets? 

I updated the GitHub secrets containing an NCBI email address and key that are required for the protein download process.

Additionally fixed the CI tests here: the `test` profile requires the ncbi credentials. 

We can order and optimise the tests a bit in the future, when the tests are more complete.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
