### PR TITLE
Fix CI tests using GitHub secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Run pipeline with test data
+    name: Run pipeline with assembly test data
     # Only run on push if this is the nf-core dev branch (merged PRs)
     if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/metapep') }}"
     runs-on: ubuntu-latest
@@ -36,9 +36,9 @@ jobs:
         with:
           version: "${{ matrix.NXF_VER }}"
 
-      - name: Run pipeline with test data
+      - name: Run pipeline with assembly test data
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
+          nextflow run ${GITHUB_WORKSPACE} -profile test_assembly_only,docker --outdir ./results
 
   profile:
     name: Run additional profile tests
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests: ["test_assembly_only", "test_bins"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
+        tests: ["test_bins", "test_coassembly"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -64,12 +64,14 @@ jobs:
 
   all_profiles:
     name: Run all additional profile tests that require ncbi credentials
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Only run on PRs from branches of nf-core/metapep repository or on push if this is the nf-core dev branch (merged PRs)
+    # (GitHub secrets are not accessible for workflows from forks)
+    if: ${{ github.event.pull_request.head.repo.full_name == 'nf-core/metapep' || (github.event_name == 'push' && github.repository == 'nf-core/metapep') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        tests: ["test_mouse", "test_tiny"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
+        tests: ["test", "test_mouse", "test_tiny"] # add further test profiles here, will be run in parallel (but only with one nextflow version)
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/conf/test_coassembly.config
+++ b/conf/test_coassembly.config
@@ -4,7 +4,7 @@
  * -------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:
- *   nextflow run nf-core/metapep -profile test_bins,<docker/singularity>
+ *   nextflow run nf-core/metapep -profile test_coassembly,<docker/singularity>
  */
 
 params {


### PR DESCRIPTION
Run CI tests that use GitHub secrets (i.e. email address and NCBI key for protein download from NCBI) also on pushes on dev branch and on PRs that are not from forks. These tests can not be run on PRs from forks, since secrets can not be accessed from forks. Before these tests were run only on commits on master, but it would be good to test also this part of the pipeline more often. 
Note that one now has to explicitly check if these tests fail, since it does not appear before merging!

Additionally, I replaced the first test with `test_assembly_only`, since the `test` profile also requires secrets. We can clean this up in the future, when the tests are complete (I created a reminder https://github.com/nf-core/metapep/issues/41).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
