### PR TITLE
Enable multiple weights for bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 
 - [#12](https://github.com/nf-core/metapep/pull/12) - Updated documentation
 - [#29](https://github.com/nf-core/metapep/pull/29) - Added data model figure to `output.md`
+- [#45](https://github.com/nf-core/metapep/pull/45) - Added support for multiple weights tables for one bin
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 
 - [#12](https://github.com/nf-core/metapep/pull/12) - Updated documentation
 - [#29](https://github.com/nf-core/metapep/pull/29) - Added data model figure to `output.md`
-- [#45](https://github.com/nf-core/metapep/pull/45) - Added support for multiple weights tables for one bin
+- [#45](https://github.com/nf-core/metapep/pull/45) - Added support for multiple weights tables for one bin (i.e. co-assembly input)
 
 ### `Changed`
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -141,14 +141,14 @@ def check_samplesheet(args):
 
     # check if weight_path is valid
     for type, weights_path in zip(input_table["type"], input_table["weights_path"]):
-        if not type == "assembly" and not pd.isnull(weights_path):
-            sys.exit(
-                "Input file "
-                + args.input.name
-                + " contains 'weights_path' specified for type '"
-                + type
-                + "'! Currently input weights are only supported for type 'assembly'."
-            )
+        #if not type == "assembly" and not pd.isnull(weights_path):
+        #    sys.exit(
+        #        "Input file "
+        #        + args.input.name
+        #        + " contains 'weights_path' specified for type '"
+        #        + type
+        #        + "'! Currently input weights are only supported for type 'assembly'."
+        #    )
         if not pd.isnull(weights_path) and not weights_path.lower().endswith(".tsv"):
             sys.exit(
                 "In "

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -141,14 +141,14 @@ def check_samplesheet(args):
 
     # check if weight_path is valid
     for type, weights_path in zip(input_table["type"], input_table["weights_path"]):
-        #if not type == "assembly" and not pd.isnull(weights_path):
-        #    sys.exit(
-        #        "Input file "
-        #        + args.input.name
-        #        + " contains 'weights_path' specified for type '"
-        #        + type
-        #        + "'! Currently input weights are only supported for type 'assembly'."
-        #    )
+        if not (type == "assembly" or type == "bins") and not pd.isnull(weights_path):
+            sys.exit(
+                "Input file "
+                + args.input.name
+                + " contains 'weights_path' specified for type '"
+                + type
+                + "'! Currently input weights are only supported for type 'assembly' or 'bins."
+            )
         if not pd.isnull(weights_path) and not weights_path.lower().endswith(".tsv"):
             sys.exit(
                 "In "

--- a/conf/test_coassembly.config
+++ b/conf/test_coassembly.config
@@ -17,7 +17,4 @@ params {
 
     // Input data
     input = "https://github.com/nf-core/test-datasets/raw/metapep/samplesheets/input.coassembly.csv"
-
-    // Epitope prediction
-    pred_method = 'mhcflurry'
 }


### PR DESCRIPTION
This PR enables the usage of multiple weight files for one bin path in case of a coassembly.
This includes changing the input check and changing the `meta.id` of the bins file to a `microbiome_bare_id` which is corresponding to a specific file instead of microbiome (file in combination with weights).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
