### PR TITLE
Add label retry to download proteins process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 - [#64](https://github.com/nf-core/metapep/pull/64), [#65](https://github.com/nf-core/metapep/pull/65) - Updated the data model figure and using a white background to ensure readability in both dark and light themes.
 - [#76](https://github.com/nf-core/metapep/pull/76) - Restructure and rename `CHECK_INPUT` subworkflow to `PREPROCESS_INPUT` and move some channel logic into the subworkflow. Also `CHECK_SAMPLESHEET` module is renamed to `INPUT_TO_DATAMODEL` to have a more descriptive name and circumvent clashing with the nf-core template.
 - [#79](https://github.com/nf-core/metapep/pull/79) - Replaced multi-package BioContainers by single-package pandas BioContainer and updated containers with old pandas versions
+- [#82](https://github.com/nf-core/metapep/pull/82) - Add label `error_retry` to process `DOWNLOAD_PROTEINS`
 
 ### `Fixed`
 

--- a/modules/local/download_proteins.nf
+++ b/modules/local/download_proteins.nf
@@ -1,6 +1,7 @@
 process DOWNLOAD_PROTEINS {
     tag "$microbiome_ids"
     label 'process_low'
+    label 'error_retry'
 
     conda "conda-forge::biopython=1.78"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
<!--
# nf-core/metapep pull request

Many thanks for contributing to nf-core/metapep!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
-->

I added the label `error_retry` to the process `DOWNLOAD_PROETINS` as it may fail due to access issues to Entrez which are solved by retrying. The process itself already has 3 retries, but still when testing it sometimes failed and needed to restart.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
