### PR TITLE
Adjusted used resource request labels

### DIFF
--- a/modules/local/generate_peptides.nf
+++ b/modules/local/generate_peptides.nf
@@ -1,6 +1,6 @@
 process GENERATE_PEPTIDES {
     label 'process_long'
-    label 'process_high_memory'
+    label 'process_medium_memory'
     label 'cache_lenient'
 
     conda "conda-forge::pandas=1.5.2 conda-forge::biopython=1.79 conda-forge::numpy=1.23.5"

--- a/modules/local/merge_predictions.nf
+++ b/modules/local/merge_predictions.nf
@@ -1,5 +1,5 @@
 process MERGE_PREDICTIONS {
-    label "process_high_memory"
+    label "process_long"
     label 'cache_lenient'
 
     conda "conda-forge::pandas=1.5.2"

--- a/modules/local/merge_predictions_buffer.nf
+++ b/modules/local/merge_predictions_buffer.nf
@@ -1,6 +1,5 @@
 process MERGE_PREDICTIONS_BUFFER {
     label 'cache_lenient'
-    label 'process_medium_memory'
 
     conda "conda-forge::pandas=1.5.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
I adjusted the used labels for the process specific resource requests.

In the end I just applied minor modifications and kept the labels for the most processes as they were although the memory usages was drastically reduced. I am a bit unsure how much would be needed for reasonable big real datasets, but thought retrying with increased memory values is also not efficient. 

We can still reduce some of the values in the future if needed.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
