### PR TITLE
Feature/allow allpep lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 - [#82](https://github.com/nf-core/metapep/pull/82) - Add label `error_retry` to process `DOWNLOAD_PROTEINS`
 - [#89](https://github.com/nf-core/metapep/pull/85) - Changed the output of `UNIFY_MODEL_LENGTHS` to a logfile and fixed channellogic
 - [#90](https://github.com/nf-core/metapep/pull/90) - Removed script headers and unused imports
+- [#91](https://github.com/nf-core/metapep/pull/91) - Added new parameter to allow all input peptide lengths to be predicted, and also necessary checks to circumvent errors during predictions
 
 ### `Fixed`
 

--- a/bin/epytope_predict.py
+++ b/bin/epytope_predict.py
@@ -223,7 +223,7 @@ def syfpeithi_normalize(predictions):  # SYFPEITHI NORMALIZATION
         scored_lengths = {l for l, score in zip(lengths, predictions[allele]) if not pd.isna(score)}
         max_vals = {l: get_allele_model_max_value(conv_allele, l) for l in scored_lengths}
         new_scores = [
-            np.nan if pd.isna(score) else score / max_vals[l] for score, l in zip(predictions[allele], lengths)
+            np.nan if pd.isna(score) or max_vals[l]==None else score / max_vals[l] for score, l in zip(predictions[allele], lengths)
         ]
         predictions[allele] = new_scores
 
@@ -279,10 +279,7 @@ try:
             logging.warning(f"PREDICTION ({predictor.name} {predictor.version}) - {str(message)}")
 
     # Add missing alleles as NA values
-    for missing_allele in [str(allele) for allele in alleles if str(allele) not in predictions.columns]:
-        logging.warning(
-            f"PREDICTION ({predictor.name} {predictor.version}) yielded no results for allele {missing_allele}"
-        )
+    for missing_allele in [allele for allele in alleles if allele not in predictions.columns]:
         predictions[missing_allele] = np.NaN
 
     # Normalize syfpeithi scores

--- a/bin/epytope_predict.py
+++ b/bin/epytope_predict.py
@@ -223,7 +223,8 @@ def syfpeithi_normalize(predictions):  # SYFPEITHI NORMALIZATION
         scored_lengths = {l for l, score in zip(lengths, predictions[allele]) if not pd.isna(score)}
         max_vals = {l: get_allele_model_max_value(conv_allele, l) for l in scored_lengths}
         new_scores = [
-            np.nan if pd.isna(score) or max_vals[l]==None else score / max_vals[l] for score, l in zip(predictions[allele], lengths)
+            np.nan if pd.isna(score) or max_vals[l] == None else score / max_vals[l]
+            for score, l in zip(predictions[allele], lengths)
         ]
         predictions[allele] = new_scores
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,6 +25,7 @@ params {
 
     // predict epitopes
     pred_method = 'syfpeithi'
+    allow_all_peptide_lengths = false
     syfpeithi_score_threshold = 0.5
     mhcflurry_mhcnuggets_score_threshold = 0.426
     show_supported_models = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,7 +25,7 @@ params {
 
     // predict epitopes
     pred_method = 'syfpeithi'
-    allow_all_peptide_lengths = false
+    allow_inconsistent_pep_lengths = false
     syfpeithi_score_threshold = 0.5
     mhcflurry_mhcnuggets_score_threshold = 0.426
     show_supported_models = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -136,14 +136,12 @@
                     "type": "boolean",
                     "description": "Display help text.",
                     "fa_icon": "fas fa-question-circle",
-                    "default": false,
                     "hidden": true
                 },
                 "version": {
                     "type": "boolean",
                     "description": "Display version and exit.",
                     "fa_icon": "fas fa-question-circle",
-                    "default": false,
                     "hidden": true
                 },
                 "publish_dir_mode": {
@@ -167,7 +165,6 @@
                     "type": "boolean",
                     "description": "Send plain-text email instead of HTML.",
                     "fa_icon": "fas fa-remove-format",
-                    "default": false,
                     "hidden": true
                 },
                 "max_multiqc_email_size": {
@@ -182,7 +179,6 @@
                     "type": "boolean",
                     "description": "Do not use coloured log outputs.",
                     "fa_icon": "fas fa-palette",
-                    "default": false,
                     "hidden": true
                 },
                 "hook_url": {
@@ -221,7 +217,6 @@
                     "type": "boolean",
                     "fa_icon": "far fa-eye-slash",
                     "description": "Show all params when using `--help`",
-                    "default": false,
                     "hidden": true,
                     "help_text": "By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters."
                 },
@@ -229,7 +224,6 @@
                     "type": "boolean",
                     "fa_icon": "far fa-check-circle",
                     "description": "Validation of parameters fails when an unrecognised parameter is found.",
-                    "default": false,
                     "hidden": true,
                     "help_text": "By default, when an unrecognised parameter is found, it returns a warinig."
                 },
@@ -237,7 +231,6 @@
                     "type": "boolean",
                     "fa_icon": "far fa-check-circle",
                     "description": "Validation of parameters in lenient more.",
-                    "default": false,
                     "hidden": true,
                     "help_text": "Allows string values that are parseable as numbers or booleans. For further information see [JSONSchema docs](https://github.com/everit-org/json-schema#lenient-mode)."
                 }
@@ -270,6 +263,12 @@
                     "type": "integer",
                     "default": 11,
                     "description": "Maximum length of produced peptides.",
+                    "fa_icon": "fas fa-cogs"
+                },
+                "allow_all_peptide_lengths": {
+                    "type": "boolean",
+                    "description": "Only takes effect for `pred_method 'syfpeithi'` Allow all peptide lengths within the range of `min_pep_len` to `max_pep_len` without reducing them to the matching allele models",
+                    "hidden": true,
                     "fa_icon": "fas fa-cogs"
                 },
                 "pred_method": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -265,7 +265,7 @@
                     "description": "Maximum length of produced peptides.",
                     "fa_icon": "fas fa-cogs"
                 },
-                "allow_all_peptide_lengths": {
+                "allow_inconsistent_pep_lengths": {
                     "type": "boolean",
                     "description": "Only takes effect for `pred_method 'syfpeithi'` Allow all peptide lengths within the range of `min_pep_len` to `max_pep_len` without reducing them to the matching allele models",
                     "hidden": true,

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -267,7 +267,7 @@
                 },
                 "allow_inconsistent_pep_lengths": {
                     "type": "boolean",
-                    "description": "Only takes effect for `pred_method 'syfpeithi'` Allow all peptide lengths within the range of `min_pep_len` to `max_pep_len` without reducing them to the matching allele models",
+                    "description": "Only takes effect for `pred_method 'syfpeithi'`. Allow all peptide lengths within the range of `min_pep_len` to `max_pep_len` without reducing them to the matching allele models.",
                     "hidden": true,
                     "fa_icon": "fas fa-cogs"
                 },

--- a/subworkflows/local/process_input.nf
+++ b/subworkflows/local/process_input.nf
@@ -19,7 +19,7 @@ workflow PROCESS_INPUT {
 
     // When PSSMs methods are used we can check in epytope if the model exists for the given peptide lengths
     // Only intersection of allele model lengths are used in further analysis
-    if (params.pred_method == "syfpeithi") {
+    if (params.pred_method == "syfpeithi" && !params.allow_all_peptide_lengths) {
         UNIFY_MODEL_LENGTHS (CHECK_SAMPLESHEET_CREATE_TABLES.out.samplesheet_valid)
 
         peptide_lengths = UNIFY_MODEL_LENGTHS.out.unified_pep_lens.tokenize(",")

--- a/subworkflows/local/process_input.nf
+++ b/subworkflows/local/process_input.nf
@@ -19,7 +19,7 @@ workflow PROCESS_INPUT {
 
     // When PSSMs methods are used we can check in epytope if the model exists for the given peptide lengths
     // Only intersection of allele model lengths are used in further analysis
-    if (params.pred_method == "syfpeithi" && !params.allow_all_peptide_lengths) {
+    if (params.pred_method == "syfpeithi" && !params.allow_inconsistent_pep_lengths) {
         UNIFY_MODEL_LENGTHS (CHECK_SAMPLESHEET_CREATE_TABLES.out.samplesheet_valid)
 
         peptide_lengths = UNIFY_MODEL_LENGTHS.out.unified_pep_lens.tokenize(",")


### PR DESCRIPTION
<!--
# nf-core/metapep pull request

Many thanks for contributing to nf-core/metapep!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
-->

I added a new parameter to let the user skip the check if the chosen peptide lengths can be used for all alleles. This may result in an analysis bias if alleles are compared against each other, which is the reason we included the checks and unification in the first place.

I therefore, needed to double check also in the prediction to not throw errors.

Also I deleted one logging line, which may be misinterpreted. The line stated that specific alleles did not yield any predictions, which may happen if the prediction chunk contains only unsupported peptide lengths. Therefore, the allele did in fact yield predictions, but just not for one chunk.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
