### PR TITLE
Fix typo in peptide lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs
 - [#58](https://github.com/nf-core/metapep/pull/58) - Ensured deterministic microbiome_id and entity_id assignments.
 - [#62](https://github.com/nf-core/metapep/pull/62) - nf-core module prodigal is updated
 - [#77](https://github.com/nf-core/metapep/pull/77) - Remove unused github workflow files to push dockerimage to dockerhub
-- [#92](https://github.com/nf-core/metapep/pull/92) - Added check for min and max peptide length parameters
+- [#92](https://github.com/nf-core/metapep/pull/92), [#95](https://github.com/nf-core/metapep/pull/95) - Added check for min and max peptide length parameters
 
 ### `Dependencies`
 

--- a/workflows/metapep.nf
+++ b/workflows/metapep.nf
@@ -27,7 +27,7 @@ if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
 }
 
 // Exit if peptide length parameters are exchanged
-if (params.min_pep_len >= params.max_pep_len) {
+if (params.min_pep_len > params.max_pep_len) {
     error "The minimum peptide length needs to be smaller or equal than the maximum. See 'https://nf-co.re/metapep/dev/parameters' for more information."
 }
 


### PR DESCRIPTION
<!--
# nf-core/metapep pull request

Many thanks for contributing to nf-core/metapep!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
-->

I realised, that a last minute change (from > to >=) introduced a bug in the last bugfix PR (#92), throwing an error when peptide lengths min and max are the same.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
