### PR TITLE
Chunkwise processing of Entrez Download (proteins)

### DIFF
--- a/bin/download_proteins_entrez.py
+++ b/bin/download_proteins_entrez.py
@@ -378,7 +378,7 @@ def main(args=None):
 
     dict_protein_uid_acc = {}
     for protein_summary in protein_summaries:
-            dict_protein_uid_acc[protein_summary["Id"]] = protein_summary["AccessionVersion"]
+        dict_protein_uid_acc[protein_summary["Id"]] = protein_summary["AccessionVersion"]
 
     if len(proteinIds) != len(dict_protein_uid_acc.keys()):
         sys.exit(f"Unmatched size of downloaded protein ids ({len(dict_protein_uid_acc.keys())}) and input protein ids ({len(proteinIds)})")

--- a/bin/download_proteins_entrez.py
+++ b/bin/download_proteins_entrez.py
@@ -321,7 +321,8 @@ def main(args=None):
     retmax = 9999
     if len(proteinIds) > retmax:
         for n_chunk in range(1, int(len(proteinIds)/retmax)+1):
-            prot_id_chunks.append(proteinIds[n_chunk*retmax-retmax:retmax])
+            chunk_start = n_chunk*retmax-retmax
+            prot_id_chunks.append(proteinIds[chunk_start:chunk_start+retmax])
         prot_id_chunks.append(proteinIds[(n_chunk+1)*retmax-retmax:])
     else:
         prot_id_chunks.append(proteinIds)

--- a/bin/download_proteins_entrez.py
+++ b/bin/download_proteins_entrez.py
@@ -13,11 +13,6 @@ from urllib.error import HTTPError
 
 from Bio import Entrez, SeqIO
 
-# TODO
-# clean code
-# double check!
-
-
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -89,7 +84,7 @@ def get_assembly_length(assemblyId):
         sys.exit("Entrez efetch download failed!")
 
     root = ET.fromstring("<root>" + str(assembly_stats["DocumentSummarySet"]["DocumentSummary"][0]["Meta"]) + "</root>")
-    return root.find("./Stats/Stat[@category='total_length'][@sequence_tag='all']").text
+    return int(root.find("./Stats/Stat[@category='total_length'][@sequence_tag='all']").text)
 
 
 def main(args=None):
@@ -214,6 +209,11 @@ def main(args=None):
 
     ####################################################################################################
     # 2) for each taxon -> select one assembly (largest for now) and merge with input assembly ids
+    #    Selecting the "largest" assembly is not reproducible, there are taxon_ids (e.g. 83333
+    #    (E.coli K12)) which contains many duplicate assembly lengths. This results in different
+    #    numbers of downloaded proteins for each assembly, in combination with other assemblies
+    #    (as the overlap may be different between assemblies even though having the same size)
+
     print("get assembly lengths and select largest assembly for each taxon ...")
     dict_taxId_assemblyId = {}
     for tax_record in assembly_results:
@@ -235,7 +235,7 @@ def main(args=None):
 
     ####################################################################################################
     # 3) (selected) assembly -> nucleotide sequences
-    # (maybe split here)
+
     assemblyIds = dict_taxId_assemblyId.values()
     print("# selected assemblies: ", len(assemblyIds))
     print("for each assembly get nucloetide sequence IDs...")

--- a/bin/download_proteins_entrez.py
+++ b/bin/download_proteins_entrez.py
@@ -212,6 +212,7 @@ def main(args=None):
     if not success:
         sys.exit("Entrez elink download failed!")
 
+    ####################################################################################################
     # 2) for each taxon -> select one assembly (largest for now) and merge with input assembly ids
     print("get assembly lengths and select largest assembly for each taxon ...")
     dict_taxId_assemblyId = {}
@@ -232,6 +233,7 @@ def main(args=None):
     for taxId in dict_taxId_assemblyId.keys():
         print(taxId, dict_taxId_assemblyId[taxId], sep="\t", file=args.taxa_assemblies, flush=True)
 
+    ####################################################################################################
     # 3) (selected) assembly -> nucleotide sequences
     # (maybe split here)
     assemblyIds = dict_taxId_assemblyId.values()
@@ -268,6 +270,7 @@ def main(args=None):
     print("# nucleotide sequences (unique): ", len(dict_seqId_assemblyIds.keys()))
     # -> # contigs
 
+    ####################################################################################################
     # 4) nucelotide sequences -> proteins
     print("for each nucleotide sequence get proteins ...")
 
@@ -309,6 +312,7 @@ def main(args=None):
     print("# proteins (unique): ", len(proteinIds))
     # -> # proteins with refseq source (<= # IPG proteins)
 
+    ####################################################################################################
     # 5) download protein FASTAs, convert to TSV
     print("    download proteins ...")
     # (or if mem problem: assembly-wise)
@@ -361,11 +365,13 @@ def main(args=None):
     if not success:
         sys.exit("Entrez efetch download failed!")
 
+    ####################################################################################################
     # 6) write out 'entities_proteins.entrez.tsv'
     print("protein_tmp_id", "entity_name", sep="\t", file=args.entities_proteins)
     dict_assemblyId_taxId = {v: k for k, v in dict_taxId_assemblyId.items()}
     if len(dict_assemblyId_taxId) != len(dict_taxId_assemblyId):
         sys.exit("Creation of dict_assemblyId_taxId failed!")
+
     for proteinId in proteinIds:
         accVersion = dict_protein_uid_acc[proteinId]
         # write out protein_tmp_id, entity_name (taxon_id)
@@ -377,7 +383,6 @@ def main(args=None):
     # in contrast, for assemblies UIDs are written out
 
     print("Done!")
-
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
<!--
# nf-core/metapep pull request

Many thanks for contributing to nf-core/metapep!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
-->

I worked on some TODOs within the `download_proteins.py` script. Mainly double checking what exactly is downloaded, how many proteins and how the largest assembly is chosen. I left comments wherever needed and tried to make the script easier readable. Also E-Utilities is only allowing requests of 9999 ids per request and I needed to split the download requests into chunks for larger experimental setups, which is the main change of this PR.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
