### PR TITLE
Fix CI workflows: conditionally set secrets & trigger tests via tags

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -4,9 +4,6 @@ inputs:
   profile:
     description: "Profile to use"
     required: true
-  test_name:
-    description: "Test config to use"
-    required: true
   shard:
     description: "Shard number for this CI job"
     required: true
@@ -65,6 +62,16 @@ runs:
         conda-solver: libmamba
         conda-remove-defaults: true
 
+    # Set up Nextflow secrets for NCBI access
+    - name: Set Nextflow secrets conditionally for NCBI downloads
+      if: ${{ inputs.tags == 'WITH_NCBI'
+        && env.NCBI_EMAIL != ''
+        && env.NCBI_KEY != '' }}
+      shell: bash
+      run: |
+        nextflow secrets set NCBI_EMAIL "$NCBI_EMAIL"
+        nextflow secrets set NCBI_KEY "$NCBI_KEY"
+
     - name: Run nf-test
       shell: bash
       env:
@@ -73,7 +80,7 @@ runs:
         NFT_DIFF_ARGS: ${{ env.NFT_DIFF_ARGS }}
       run: |
         nf-test test \
-          --profile=+${{ inputs.profile }},${{ inputs.test_name }} \
+          --profile=+${{ inputs.profile }} \
           $(if [ -n "${{ inputs.tags }}" ]; then echo "--tag ${{ inputs.tags }}"; fi) \
           --ci \
           --changed-since HEAD^ \

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -59,6 +59,7 @@ jobs:
           echo ${{ steps.set-shards.outputs.shard }}
           echo ${{ steps.set-shards.outputs.total_shards }}
 
+  # Standard nf-test job without NCBI secrets - runs on all PRs (also from forks) and releases
   nf-test:
     name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
@@ -71,16 +72,6 @@ jobs:
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
         profile: [conda, docker, singularity]
-        test_name:
-          - "test"
-          - "test_model_information"
-          - "test_mouse_all_pep_lengths"
-          - "test_assembly_only"
-          - "test_bins_only"
-          - "test_coassembly"
-          - "test_mhcflurry"
-          - "test_mhcnuggets_1"
-          - "test_mhcnuggets_2"
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev
@@ -111,9 +102,9 @@ jobs:
           NFT_DIFF_ARGS: ${{ env.NFT_DIFF_ARGS }}
         with:
           profile: ${{ matrix.profile }}
-          test_name: ${{ matrix.test_name }}
           shard: ${{ matrix.shard }}
           total_shards: ${{ env.TOTAL_SHARDS }}
+          tags: "WITHOUT_NCBI"
 
       - name: Report test status
         if: ${{ always() }}
@@ -130,8 +121,9 @@ jobs:
             fi
           fi
 
-  # Only run on PRs from branches of nf-core/metapep repository or on push if this is the nf-core dev branch (merged PRs)
-  # (GitHub secrets are not accessible for PR workflows from forks)
+  # nf-test-with-secrets: # nf-test job with NCBI secrets
+  # Only runs from PRs that were opened from branches of the nf-core/metapep repository
+  # Github secrets are not available to PRs opened from forks
   nf-test-with-secrets:
     name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
@@ -144,11 +136,6 @@ jobs:
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
         profile: [conda, docker, singularity]
-        test_name:
-          - "test_all"
-          - "test_mouse"
-          - "test_taxa_only"
-          - "test_taxa_specific_assembly"
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev
@@ -171,14 +158,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Set up Nextflow secrets for NCBI access
-      - name: Set Nextflow secrets
-        if: env.NCBI_EMAIL != '' && env.NCBI_KEY != ''
-        shell: bash
-        run: |
-          nextflow secrets set NCBI_EMAIL "$NCBI_EMAIL"
-          nextflow secrets set NCBI_KEY "$NCBI_KEY"
-
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
@@ -191,9 +170,9 @@ jobs:
           NCBI_KEY: ${{ secrets.NCBI_KEY }}
         with:
           profile: ${{ matrix.profile }}
-          test_name: ${{ matrix.test_name }}
           shard: ${{ matrix.shard }}
           total_shards: ${{ env.TOTAL_SHARDS }}
+          tags: "WITH_NCBI"
 
       - name: Report test status
         if: ${{ always() }}
@@ -211,7 +190,7 @@ jobs:
           fi
 
   confirm-pass:
-    needs: [nf-test, nf-test-with-secrets]
+    needs: [nf-test]
     if: always()
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-confirm-pass

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test assembly and bin input") {
 

--- a/tests/pipeline/test_all.nf.test
+++ b/tests/pipeline/test_all.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_all"
     tag "pipeline"
+    tag "WITH_NCBI"
 
     test("test all input path including protein downloads") {
 

--- a/tests/pipeline/test_assembly_only.nf.test
+++ b/tests/pipeline/test_assembly_only.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_assembly_only"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test assembly input") {
 

--- a/tests/pipeline/test_bins_only.nf.test
+++ b/tests/pipeline/test_bins_only.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_bins_only"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test bin input") {
 

--- a/tests/pipeline/test_coassembly.nf.test
+++ b/tests/pipeline/test_coassembly.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_coassembly"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test coassembly input") {
 

--- a/tests/pipeline/test_mhcflurry.nf.test
+++ b/tests/pipeline/test_mhcflurry.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_mhcflurry"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test mhcflurry prediction") {
 

--- a/tests/pipeline/test_mhcnuggets_1.nf.test
+++ b/tests/pipeline/test_mhcnuggets_1.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_mhcnuggets_1"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test mhcnuggets hla type 1 prediction") {
 

--- a/tests/pipeline/test_mhcnuggets_2.nf.test
+++ b/tests/pipeline/test_mhcnuggets_2.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_mhcnuggets_2"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test mhcnuggets hla type 2 prediction") {
 

--- a/tests/pipeline/test_model_information.nf.test
+++ b/tests/pipeline/test_model_information.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_model_information"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test model information subbranch") {
 

--- a/tests/pipeline/test_mouse.nf.test
+++ b/tests/pipeline/test_mouse.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_mouse"
     tag "pipeline"
+    tag "WITH_NCBI"
 
     test("test mouse alleles within download path (allele prediction reduction)") {
 

--- a/tests/pipeline/test_mouse_all_pep_lengths.nf.test
+++ b/tests/pipeline/test_mouse_all_pep_lengths.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_mouse_all_pep_lengths"
     tag "pipeline"
+    tag "WITHOUT_NCBI"
 
     test("test mouse assembly allowing all peptide lengths") {
 

--- a/tests/pipeline/test_taxa_only.nf.test
+++ b/tests/pipeline/test_taxa_only.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_taxa_only"
     tag "pipeline"
+    tag "WITH_NCBI"
 
     test("test taxa input") {
 

--- a/tests/pipeline/test_taxa_specific_assembly.nf.test
+++ b/tests/pipeline/test_taxa_specific_assembly.nf.test
@@ -4,6 +4,7 @@ nextflow_pipeline {
     script "main.nf"
     profile "test_taxa_specific_assembly"
     tag "pipeline"
+    tag "WITH_NCBI"
 
     test("test taxa input with assembly id") {
 


### PR DESCRIPTION
<!--
# nf-core/metapep pull request

Many thanks for contributing to nf-core/metapep!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

The split of tests in PR #169 did not work correctly. This PR fixes that by conditionally setting nextflow secrets for the 4 test profiles that need secrets (test_all, test_mouse, test_taxa_only, test_taxa_specific_assembly). Tests for those will only be triggered when a PR is opened from a branch of the `nf-core/metapep` repo.

The other test profiles are always tested when there is a PR to `nf-core/metapep`, also when opened from a fork. 
They do not need to have secrets set, so this will be skipped. 
The tests are now triggered based on the tags `WITH_NCBI` and `WITHOUT_NCBI`.

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metapep _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
